### PR TITLE
Add the strip accent pattern

### DIFF
--- a/docs/patterns/_strip.md
+++ b/docs/patterns/_strip.md
@@ -1,0 +1,38 @@
+---
+collection: patterns
+title: Strips
+---
+
+## Strip accent
+The purpose of the strip accent pattern displays content with a highlighted
+site accent strip style.
+
+<section class="p-strip--accent">
+  <div class="row">
+    <h2>.p-strip--accent</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip--accent">
+  <div class="row">
+    <h2>.p-strip--accent</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+```

--- a/examples/_patterns_strip-accent.html
+++ b/examples/_patterns_strip-accent.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vanilla Brochure Theme | Strip accent</title>
+    <!-- stylesheets -->
+    <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css" />
+  </head>
+  <body>
+    <section class="p-strip--accent">
+      <div class="row">
+        <h2>.p-strip--accent</h2>
+      </div>
+      <div class="row">
+        <div class="col-6">
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </div>
+        <div class="col-6">
+          <img src="http://placehold.it/150x150" alt="Placeholder image" />
+        </div>
+      </div>
+    </section>
+  </body>
+</html>

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -1,0 +1,11 @@
+// Functions used across multiple patterns or utils
+
+// Returns the font color to be presented on the passed background-color
+// variable.
+@function determine-text-color($background-color) {
+  @if (lightness($background-color) > 50) {
+    @return $color-mid-dark;
+  } @else {
+    @return $color-x-light;
+  }
+}

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,0 +1,8 @@
+@mixin theme-p-strip {
+
+  .p-strip--accent {
+    @extend %strip;
+    background-color: $color-accent;
+    color: determine-text-color($color-accent);
+  }
+}

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,1 +1,2 @@
 // Theme specific settings
+$color-accent:            #2c001e !default;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -2,6 +2,10 @@
 @import
 'vanilla-framework/scss/build';
 
+// Global Sass functions
+@import
+'global_functions';
+
 // Import theme settings
 @import
 'settings';
@@ -9,11 +13,13 @@
 // Import theme pattern files
 @import
 'patterns_lists',
-'patterns_media-object';
+'patterns_media-object',
+'patterns_strip';
 
 @mixin vanilla-brochure-theme {
 
   //  Include theme pattern mixins
   @include theme-p-lists;
   @include theme-p-media-object;
+  @include theme-p-strip;
 }


### PR DESCRIPTION
## Done
Built, documented and created an example of the strip--accent pattern. 

## QA
- Run `gulp develop`
- Open the /examples/_patterns_strip-accent.html
- Check that the strip is the same as the others but used the `$color-accent` as the background-color
- Change the `$color-accent` value to a few different colours and see the text colour changes as required
- Check the documentation is ok

## Details
Fixes https://github.com/ubuntudesign/vanilla-brochure-theme/issues/8

## Screenshots
![vanilla brochure theme strip accent](https://cloud.githubusercontent.com/assets/1413534/22653988/37826de4-ec83-11e6-844c-b4b246c126bb.png)

