### PR TITLE
Utility class for positioning images at the top and bottom

### DIFF
--- a/docs/utilities/_image-position.md
+++ b/docs/utilities/_image-position.md
@@ -1,0 +1,63 @@
+---
+collection: utilities
+title: Image position
+---
+
+Image position is a utility to position an image to the top or bottom of a
+parent container. In most cases it would be a strip.
+
+## Position bottom
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>.u-image--bottom</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>.u-image--bottom</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom" />
+    </div>
+  </div>
+</section>
+```
+
+## Position top
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>.u-image--bottom</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>.u-image--bottom</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+    </div>
+  </div>
+</section>
+```

--- a/docs/utilities/_image-position.md
+++ b/docs/utilities/_image-position.md
@@ -3,8 +3,8 @@ collection: utilities
 title: Image position
 ---
 
-Image position is a utility to position an image to the top or bottom of a
-parent container. In most cases it would be a strip.
+Image position is a utility to position an image within a parent container. In
+most cases it would be a strip. This only effects medium and large screen sizes.
 
 ## Position bottom
 

--- a/docs/utilities/_image-position.md
+++ b/docs/utilities/_image-position.md
@@ -11,7 +11,7 @@ parent container. In most cases it would be a strip.
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>.u-image--bottom</h2>
+      <h2>Image position - bottom</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
@@ -24,7 +24,7 @@ parent container. In most cases it would be a strip.
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>.u-image--bottom</h2>
+      <h2>Image position - bottom</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
@@ -39,7 +39,7 @@ parent container. In most cases it would be a strip.
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>.u-image--bottom</h2>
+      <h2>Image position - top</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
@@ -52,11 +52,124 @@ parent container. In most cases it would be a strip.
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>.u-image--bottom</h2>
+      <h2>Image position - top</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
       <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+    </div>
+  </div>
+</section>
+```
+
+## Position top right
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - top right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - top right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
+    </div>
+  </div>
+</section>
+```
+
+## Position top left
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - top left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>
+
+```html
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - top left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>
+```
+
+## Position bottom right
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - bottom right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>Image position - bottom right</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
+    </div>
+  </div>
+</section>
+```
+
+## Position bottom left
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - bottom left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - bottom left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/bottom-left.html
+++ b/examples/utilities/image-position/bottom-left.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image postion / Bottom left
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - bottom left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/bottom-right.html
+++ b/examples/utilities/image-position/bottom-right.html
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Image position / Top
+title: Image postion / Bottom right
 category: _patterns
 ---
 
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>Image position - top</h2>
+      <h2>Image position - bottom right</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/bottom.html
+++ b/examples/utilities/image-position/bottom.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image postion / Bottom
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>.u-image--bottom</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--bottom" />
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/bottom.html
+++ b/examples/utilities/image-position/bottom.html
@@ -7,7 +7,7 @@ category: _patterns
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>.u-image--bottom</h2>
+      <h2>Image position - bottom</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">

--- a/examples/utilities/image-position/left.html
+++ b/examples/utilities/image-position/left.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image postion / Left
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/right.html
+++ b/examples/utilities/image-position/right.html
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Image position / Top
+title: Image postion / Right
 category: _patterns
 ---
 
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>Image position - top</h2>
+      <h2>Image position - right</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--right" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/top-left.html
+++ b/examples/utilities/image-position/top-left.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image postion / Top left
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
+    </div>
+    <div class="col-6">
+      <h2>Image position - top left</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+  </div>
+</section>

--- a/examples/utilities/image-position/top-right.html
+++ b/examples/utilities/image-position/top-right.html
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Image position / Top
+title: Image postion / Top right
 category: _patterns
 ---
 
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <h2>Image position - top</h2>
+      <h2>Image position - top right</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
     </div>
     <div class="col-6">
-      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
     </div>
   </div>
 </section>

--- a/examples/utilities/image-position/top.html
+++ b/examples/utilities/image-position/top.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Image position / Top
+category: _patterns
+---
+
+<section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
+  <div class="row">
+    <div class="col-6">
+      <h2>.u-image--top</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" class="u-image-position--top" />
+    </div>
+  </div>
+</section>

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -17,6 +17,10 @@
 'patterns_strip',
 'patterns_divider';
 
+// Import theme utility files
+@import
+'utilities_image-position';
+
 @mixin vanilla-brochure-theme {
 
   //  Include theme pattern mixins
@@ -24,4 +28,8 @@
   @include theme-p-media-object;
   @include theme-p-strip;
   @include theme-p-divider;
+
+  //  Include theme utility mixins
+  @include theme-u-image-position;
+
 }

--- a/scss/_utilities_image-position.scss
+++ b/scss/_utilities_image-position.scss
@@ -1,0 +1,23 @@
+// Create utility class for positioning images at top or bottom of the section
+
+@mixin theme-u-image-position {
+  .u-image-position {
+    @media only (min-width: $breakpoint-medium) {
+      position: relative;
+
+      [class*='col-'] {
+        position: static;
+      }
+
+      &--top {
+        position: absolute;
+        top: 0;
+      }
+
+      &--bottom {
+        bottom: 0;
+        position: absolute;
+      }
+    }
+  }
+}

--- a/scss/_utilities_image-position.scss
+++ b/scss/_utilities_image-position.scss
@@ -18,6 +18,16 @@
         bottom: 0;
         position: absolute;
       }
+
+      &--left {
+        left: 0;
+        position: absolute;
+      }
+
+      &--right {
+        position: absolute;
+        right: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done
Created an image-position utility to stick an image to the top or bottom of a selected parent container. 

## QA
- Run `gulp jekyll`
- Check the examples:
 - http://127.0.0.1:4001/vanilla-brochure-theme/examples/utilities/image-position/top/
 - http://127.0.0.1:4001/vanilla-brochure-theme/examples/utilities/image-position/bottom/
- Check the documentation is ok
- Check over the code

## Details
Fixes https://github.com/ubuntudesign/vanilla-brochure-theme/issues/6