### PR TITLE
Add card--overlay

### DIFF
--- a/docs/patterns/card.md
+++ b/docs/patterns/card.md
@@ -1,0 +1,32 @@
+---
+collection: patterns
+title: Card
+---
+
+## Card overlay
+The purpose of the card overlay pattern is to make the text visible in
+conjunction with a strip image.
+
+<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/364631d0-desktop-overview-hero.jpg?w=1024')">
+  <div class="row">
+    <div class="col-12 prefix-6">
+      <div class="p-card--overlay">
+        <h2>Card / Overlay</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/364631d0-desktop-overview-hero.jpg?w=1024')">
+  <div class="row">
+    <div class="col-12 prefix-6">
+      <div class="p-card--overlay">
+        <h2>Card / Overlay</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+    </div>
+  </div>
+</section>
+```

--- a/examples/patterns/card/overlay.html
+++ b/examples/patterns/card/overlay.html
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Card / Overlay
+category: _patterns
+---
+
+<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/364631d0-desktop-overview-hero.jpg?w=1024')">
+  <div class="row">
+    <div class="col-12 prefix-6">
+      <div class="p-card--overlay">
+        <h2>Card / Overlay</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -1,0 +1,17 @@
+// Brochure themes card styling
+@mixin theme-p-card {
+  @include theme-p-card--overlay;
+}
+
+// Pattern should be created for strips with bg images
+@mixin theme-p-card--overlay {
+  .p-card--overlay {
+    $bg-color: rgba($color-x-light, .85);
+    background: $bg-color;
+    padding: 1.333rem;
+
+    @media only (min-width: $breakpoint-medium) {
+      padding: 1.25rem;
+    }
+  }
+}

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -9,6 +9,7 @@
     &--overlay {
       $bg-color: rgba($color-x-light, .85);
       background: $bg-color;
+      color: $color-dark;
       padding: 1.3333rem;
 
       @media only (min-width: $breakpoint-medium) {

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -5,13 +5,15 @@
 
 // Pattern should be created for strips with bg images
 @mixin theme-p-card--overlay {
-  .p-card--overlay {
-    $bg-color: rgba($color-x-light, .85);
-    background: $bg-color;
-    padding: 1.333rem;
+  .p-card {
+    &--overlay {
+      $bg-color: rgba($color-x-light, .85);
+      background: $bg-color;
+      padding: 1.3333rem;
 
-    @media only (min-width: $breakpoint-medium) {
-      padding: 1.25rem;
+      @media only (min-width: $breakpoint-medium) {
+        padding: 1.25rem;
+      }
     }
   }
 }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -7,7 +7,7 @@
 @mixin theme-p-list--split {
 
   [class*='p-list'] {
-    
+
     &.is-split {
 
       @media (min-width: $breakpoint-medium) {

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -1,6 +1,6 @@
 // Brochure themes media-object styling
 @mixin theme-p-media-object {
-  
+
   .p-media-object {
     display: flex;
 

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -12,6 +12,7 @@
 
 // Import theme pattern files
 @import
+'patterns_card',
 'patterns_lists',
 'patterns_media-object',
 'patterns_strip',
@@ -20,6 +21,7 @@
 @mixin vanilla-brochure-theme {
 
   //  Include theme pattern mixins
+  @include theme-p-card;
   @include theme-p-lists;
   @include theme-p-media-object;
   @include theme-p-strip;


### PR DESCRIPTION
## Done
Add the card--overlay pattern.

## QA
- Run `gulp jekyll`
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/card/overlay/
- Make sure it matches [the design spec](https://github.com/ubuntudesign/vanilla-brochure-theme-design/blob/master/Card/card-overlay.md).

## Details
Fixes https://github.com/ubuntudesign/vanilla-brochure-theme/issues/2