### PR TITLE
Add button .is-wide/large pattern variants

### DIFF
--- a/docs/patterns/_buttons.md
+++ b/docs/patterns/_buttons.md
@@ -1,0 +1,18 @@
+---
+collection: patterns
+title: Buttons
+---
+
+These are state patterns supplementing existing button classes.
+
+<button class="p-button--neutral is-wide">Wide button</button>
+
+```html
+<button class="p-button--neutral is-wide">Wide button</button>
+```
+
+<button class="p-button--neutral is-large">Large button</button>
+
+```html
+<button class="p-button--neutral is-large">Large button</button>
+```

--- a/examples/patterns/buttons/large.html
+++ b/examples/patterns/buttons/large.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Buttons / Large
+category: _patterns
+---
+
+<button class="p-button--neutral is-large">Large button</button>

--- a/examples/patterns/buttons/wide.html
+++ b/examples/patterns/buttons/wide.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Buttons / Wide
+category: _patterns
+---
+
+<button class="p-button--neutral is-wide">Wide button</button>

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -1,0 +1,21 @@
+// Default button styling
+@mixin theme-p-button {
+  @include theme-p-button--wide;
+  @include theme-p-button--large;
+
+}
+
+@mixin theme-p-button--wide {
+
+  [class*='p-button'].is-wide {
+    width: 100%;
+  }
+}
+
+@mixin theme-p-button--large {
+
+  [class*='p-button'].is-large {
+    border-width: 1.5px;
+    padding: 1.03125rem 2.25rem;
+  }
+}

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -16,6 +16,7 @@
 'patterns_media-object',
 'patterns_strip',
 'patterns_heading-icon',
+'patterns_buttons',
 'patterns_divider';
 
 // Import theme utility files
@@ -25,6 +26,7 @@
 @mixin vanilla-brochure-theme {
 
   //  Include theme pattern mixins
+  @include theme-p-button;
   @include theme-p-lists;
   @include theme-p-media-object;
   @include theme-p-strip;


### PR DESCRIPTION
## Done

Add two button pattern state variants `.is-large` / `.is-wide`

## QA

- Pull code
- Run `gulp jekyll`
- View [http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/buttons/wide/](http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/buttons/wide/)
- View [http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/buttons/large/](http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/buttons/large/)
- Cross ref with[ design spec ](https://github.com/ubuntudesign/vanilla-brochure-theme-design/tree/master/Buttons)

Fixes #1